### PR TITLE
Update UrlHelpers.fs

### DIFF
--- a/FSharpCrawler/UrlHelpers.fs
+++ b/FSharpCrawler/UrlHelpers.fs
@@ -53,10 +53,7 @@ let getNormalizedBaseUrl (inputUrl : string) =
     normalizeUrl(Regex.Match(inputUrl, softBaseHostUrlPattern).Value)
 
 
-let urljoin (inputUrl : string, baseUrl : string) =
-    if inputUrl.StartsWith("http") then inputUrl
-    elif (inputUrl.StartsWith('/') || baseUrl.EndsWith('/')) then normalizeUrl(baseUrl + inputUrl)
-    else normalizeUrl(baseUrl + "/" + inputUrl)
+let urljoin (baseUrl : string, relativeUrl : string) = Uri(Uri(baseUrl), relativeUrl).ToString()
     
 let getExplorableUrls (urls : seq<string>, baseUrl : string) = 
     urls

--- a/FSharpCrawler/UrlHelpers.fs
+++ b/FSharpCrawler/UrlHelpers.fs
@@ -52,6 +52,12 @@ let transformRelativeToFullUrl (inputUrl : string, baseUrl : string) =
 let getNormalizedBaseUrl (inputUrl : string) =
     normalizeUrl(Regex.Match(inputUrl, softBaseHostUrlPattern).Value)
 
+
+let urljoin (inputUrl : string, baseUrl : string) =
+    if inputUrl.StartsWith("http") then inputUrl
+    elif (inputUrl.StartsWith('/') || baseUrl.EndsWith('/')) then normalizeUrl(baseUrl + inputUrl)
+    else normalizeUrl(baseUrl + "/" + inputUrl)
+    
 let getExplorableUrls (urls : seq<string>, baseUrl : string) = 
     urls
         |> Seq.map(fun x -> x.Replace("%20","").Replace(" ", ""))


### PR DESCRIPTION
Construct a full (“absolute”) URL by combining a “base URL” (base) with another URL (url) like url [urljoin](https://docs.python.org/2/library/urlparse.html#urlparse.urljoin) in Python we can use 
```python
>>> urljoin("https://www.saibatudomt.com.br/", "2019/09/cuiaba-bancos-sao-condenados-por-transferir-dinheiro-para-conta-errada.html")
'https://www.saibatudomt.com.br/2019/09/cuiaba-bancos-sao-condenados-por-transferir-dinheiro-para-conta-errada.html'

>>> urljoin("https://www.saibatudomt.com.br/", "/2019/09/cuiaba-bancos-sao-condenados-por-transferir-dinheiro-para-conta-errada.html")
'https://www.saibatudomt.com.br/2019/09/cuiaba-bancos-sao-condenados-por-transferir-dinheiro-para-conta-errada.html'

>>> urljoin("https://www.saibatudomt.com.br/", "https://www.saibatudomt.com.br/2019/09/cuiaba-bancos-sao-condenados-por-transferir-dinheiro-para-conta-errada.html")
'https://www.saibatudomt.com.br/2019/09/cuiaba-bancos-sao-condenados-por-transferir-dinheiro-para-conta-errada.html'
```